### PR TITLE
Validate that all properties are strings

### DIFF
--- a/src/mqttgw.erl
+++ b/src/mqttgw.erl
@@ -858,6 +858,7 @@ validate_envelope(Val) ->
 
     true = is_binary(Payload),
     true = is_map(Properties),
+    true = lists:all(fun({_, V}) -> is_binary(V) end, maps:to_list(Properties)),
     Val.
 
 -spec parse_envelope(connection_mode(), binary()) -> message().


### PR DESCRIPTION
When some property value is not a string then the broker fails with unmatched function argument [here](https://github.com/vernemq/vernemq/blob/master/apps/vmq_commons/src/vmq_parser_mqtt5.erl#L565-L571) if some is connected with MQTT v5 causing restart and reconnection of all clients.

According to MQTT v5 standard all properties must have string values so `properties` in v3 envelope must be strings too for compatibility.